### PR TITLE
Docs: DOJO alignment + PR template (issue #26)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+
+## Changes
+
+## Testing
+
+- [ ] cargo fmt -- --check
+- [ ] cargo clippy -- -D warnings
+- [ ] cargo test
+
+## Dojo Checklist
+
+- [ ] Destructive operations require explicit confirmation (no hidden defaults).
+- [ ] User choice is preserved (e.g., MBR vs GPT is always selectable).
+- [ ] Logs are clear, noisy, and defensive (no swallowed errors).
+- [ ] Documentation updated if user-facing behavior changed.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This installer **DESTROYS THE TARGET DISK**.
 - There is no undo
 
 You will be asked to confirm before any destructive action. **Double-check the device name every time.**
+In the TUI you must type confirmation phrases (e.g., `DESTROY`, then `FLASH`). In CLI mode you must pass `--yes-i-know`.
 
 ---
 
@@ -169,9 +170,3 @@ See [LICENSE](LICENSE) for details.
 ---
 
 > *Anyone can cook. This one just boots cleanly.* 🐀
-# codex test
-# codex test
-# codex test
-# codex test
-# codex test
-# codex test

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -21,6 +21,12 @@ This keeps releases small, auditable, and reproducible.
 
 ---
 
+## 🥋 Development Principles
+
+Follow [DOJO.md](DOJO.md) for code guidelines, Git workflow, and destructive-action safeguards.
+
+---
+
 ## 🔧 Build Prerequisites
 
 ### Rust Toolchain

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -81,8 +81,9 @@ The TUI guides you through:
 2. Choosing image source (download or local)
 3. Selecting partition scheme (MBR recommended)
 4. Confirming you have backed up your data (required)
-5. Creating your first-boot user (no autologin)
-6. Final confirmation before flashing
+5. Typing explicit confirmation phrases (e.g., `DESTROY`, then `FLASH`)
+6. Creating your first-boot user (no autologin)
+7. Final confirmation before flashing
 
 Defaults: MBR scheme, EFI 1 GiB, BOOT 2 GiB, ROOT end 1800 GiB, DATA remainder.
 
@@ -105,6 +106,8 @@ This will:
 2. Download latest UEFI firmware
 3. Partition and format `/dev/sda`
 4. Install Fedora with UEFI boot
+
+CLI mode always requires `--yes-i-know` to proceed with destructive actions.
 
 ---
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,6 +7,7 @@ This project uses Rust tooling for release automation. The authoritative workflo
 - A clean working tree (unless `--allow-dirty` is explicitly used).
 - Cargo.toml version values must be strict SemVer (`X.Y.Z`).
 - Tags must be `vX.Y.Z` with no extra text.
+- Follow [DOJO.md](DOJO.md) for commit messaging, branching, and safety rules.
 
 ## Standard Release Flow
 


### PR DESCRIPTION
Closes #26.

- Adds PR template
- Aligns README/Quickstart/Deployment/Releasing with DOJO
- Removes remaining stray “codex test” references
- Docs-only changes

Validation:
- cargo fmt -- --check
