### PR TITLE
docs: define dojo catalogue schema (issue #50)

### DIFF
--- a/docs/architecture/adr-001-catalogue-schema.md
+++ b/docs/architecture/adr-001-catalogue-schema.md
@@ -1,0 +1,61 @@
+# ADR 001: Dojo Program Catalogue Schema
+
+## Status
+Accepted — 2026-02-02
+
+## Context
+The Dojo Program Catalogue drives the curated software choices that users encounter in the TUI. The catalogue must express categories, defaults, and safe alternatives while describing package names for every supported distribution. We need a Rust-friendly representation that can be loaded with `serde` and stays close to the existing TOML-heavy configuration style in this repository.
+
+## Decision
+- Format: continue using **TOML** because the repo already uses it for configuration, it deserializes cleanly with `serde`, and it supports nested table arrays that align with category/program grouping.
+- Schema shape:
+  - `[[category]]` anchors each intent group (e.g., "Web Browser"). Fields per category include `id`, `label`, `description`, and a `programs` table array.
+  - Each `[[category.programs]]` entry represents a curated choice and exposes:
+    - `id`, `label`, `description` (user-facing metadata).
+    - `default` (boolean, only one per category should be true).
+    - `package_names` (map of distribution keys to `string[]`, e.g., `dnf`, `apt`, `pacman`).
+    - `reason_why` (concise explanation of the trade-off).
+    - Optional gating metadata (`requires_expert_mode`, `gated_message`).
+- The schema can be loaded into Rust via the structs below, enabling multi-distro lookups and gating logic.
+
+## Minimal Rust prototype
+```rust
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Deserialize)]
+pub struct DojoCatalogue {
+    pub categories: Vec<Category>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Category {
+    pub id: String,
+    pub label: String,
+    pub description: String,
+    pub programs: Vec<Program>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Program {
+    pub id: String,
+    pub label: String,
+    pub description: String,
+    pub default: bool,
+    pub package_names: HashMap<String, Vec<String>>,
+    pub reason_why: String,
+    pub gating: Option<Gating>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Gating {
+    pub requires_expert_mode: bool,
+    pub gated_message: Option<String>,
+}
+```
+
+## Consequences
+- Documentation and tooling can continue to favor TOML while Rust code deserializes directly into strongly typed structs.
+- Multi-distro support is explicit via the `package_names` map, enabling installers to pick matching package managers at runtime.
+- The gating metadata lets the UI hide advanced choices unless `requires_expert_mode` is satisfied.
+- The example file at `docs/architecture/dojo_catalogue_schema_example.toml` illustrates the full schema and can be treated as input for future catalogue readers.

--- a/docs/architecture/dojo_catalogue_schema_example.toml
+++ b/docs/architecture/dojo_catalogue_schema_example.toml
@@ -1,0 +1,70 @@
+[[category]]
+id = "web-browser"
+label = "Web Browser"
+description = "Essential for browsing guides, releases, and Dojo documentation."
+
+[[category.programs]]
+id = "firefox"
+label = "Firefox ESR"
+description = "Stable, supported, and privacy-minded."
+default = true
+reason_why = "Ships with ESR updates on all supported distros, so we minimize regressions."
+[category.programs.package_names]
+dnf = ["firefox"]
+apt = ["firefox-esr"]
+pacman = ["firefox-esr"]
+
+[[category.programs]]
+id = "chromium"
+label = "Chromium"
+description = "Sandboxed and fast, but occasionally lags on ARM builds."
+default = false
+reason_why = "A good alternative for users migrating from Chrome; builds are available via pacman and apt."
+[category.programs.package_names]
+dnf = ["chromium"]
+apt = ["chromium"]
+pacman = ["chromium"]
+
+[[category.programs]]
+id = "ungoogled-chromium"
+label = "Ungoogled Chromium"
+description = "Privacy-hardened fork, requires expert mode due to manual patches."
+default = false
+reason_why = "Avoids telemetry but needs extra maintenance."
+[category.programs.package_names]
+dnf = ["ungoogled-chromium"]
+apt = ["ungoogled-chromium"]
+pacman = ["ungoogled-chromium"]
+[category.programs.gating]
+requires_expert_mode = true
+gated_message = "Expert mode only: user must understand how to handle manual updates."
+
+[[category]]
+id = "text-editor"
+label = "Text Editor"
+description = "Choice of editor for terminal-first workflows."
+
+[[category.programs]]
+id = "nano"
+label = "GNU nano"
+description = "Simple, default-friendly editor with minimal keystrokes."
+default = true
+reason_why = "Every distro ships nano; perfect for quick edits without learning vim."
+[category.programs.package_names]
+dnf = ["nano"]
+apt = ["nano"]
+pacman = ["nano"]
+
+[[category.programs]]
+id = "neovim"
+label = "Neovim"
+description = "Modern vim fork with Lua support; recommended for power users."
+default = false
+reason_why = "Offers plugin support, but new users should be comfortable with modal editing."
+[category.programs.package_names]
+dnf = ["neovim"]
+apt = ["neovim"]
+pacman = ["neovim"]
+[category.programs.gating]
+requires_expert_mode = true
+gated_message = "Expert mode only: Neovim configuration will not be auto-generated."


### PR DESCRIPTION
Closes #50.\n\n- add ADR describing the TOML-based catalogue schema and how Rust will deserialize it\n- provide a worked example TOML catalogue covering categories, defaults, alternatives, and gating metadata\n\nTests:\n- cargo fmt -- --check\n- cargo clippy --all-targets --all-features -- -D warnings\n- cargo test --all-targets