### PR TITLE
chore: automate OS link health check (issue #45)

### DIFF
--- a/.github/workflows/os-download-links.yml
+++ b/.github/workflows/os-download-links.yml
@@ -1,0 +1,19 @@
+name: OS download link health
+
+on:
+  schedule:
+    - cron: '0 12 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-rust@v1
+        with:
+          toolchain: stable
+          profile: minimal
+      - name: Run OS link checker
+        working-directory: .
+        run: cargo run -p os-link-checker -- --config docs/os-download-links.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "mash-installer",
     "tools/mash-release",
     "tools/mash-tools",
+    "tools/os-link-checker",
 ]
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 MASH is an opinionated installer that automates Fedora KDE installation on Raspberry Pi 4 with UEFI boot support. It is **destructive by design** — it will completely erase and repartition your target disk.
 
+[![OS download link health](https://github.com/drtweak86/MASH/actions/workflows/os-download-links.yml/badge.svg)](https://github.com/drtweak86/MASH/actions/workflows/os-download-links.yml)
+
 ---
 
 ## ✨ What MASH Does

--- a/docs/os-download-links.toml
+++ b/docs/os-download-links.toml
@@ -1,0 +1,21 @@
+# OS Download Link Health Checklist for GitHub Actions
+# Each entry is verified via HEAD requests; failures fail the workflow.
+[[links]]
+name = "Fedora Workstation"
+url = "https://getfedora.org/en/workstation/download/"
+description = "Official Fedora Workstation download page for the latest release."
+
+[[links]]
+name = "Ubuntu Desktop"
+url = "https://www.ubuntu.com/download/desktop"
+description = "Ubuntu Desktop download center covering current LTS and interim releases."
+
+[[links]]
+name = "Manjaro"
+url = "https://manjaro.org/download/"
+description = "Manjaro download page for the official editions (XFCE, KDE, GNOME)."
+
+[[links]]
+name = "Raspberry Pi OS (64-bit)"
+url = "https://www.raspberrypi.com/software/operating-systems/"
+description = "Raspberry Pi OS download matrix with 64-bit and legacy images."

--- a/tools/os-link-checker/Cargo.toml
+++ b/tools/os-link-checker/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "os-link-checker"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+anyhow = "1.0"
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "rustls-tls"] }
+serde = { version = "1.0", features = ["derive"] }
+toml = "0.7"

--- a/tools/os-link-checker/src/main.rs
+++ b/tools/os-link-checker/src/main.rs
@@ -1,0 +1,109 @@
+use anyhow::{anyhow, Context, Result};
+use reqwest::blocking::Client;
+use reqwest::{redirect::Policy, StatusCode};
+use serde::Deserialize;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+#[derive(Debug, Deserialize)]
+struct LinksFile {
+    links: Vec<OsLink>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OsLink {
+    name: String,
+    url: String,
+    description: Option<String>,
+}
+
+fn main() -> Result<()> {
+    let config_path = config_path_env()?;
+    let contents = fs::read_to_string(&config_path)
+        .with_context(|| format!("failed to read {}", config_path.display()))?;
+    let links_file: LinksFile = toml::from_str(&contents)
+        .with_context(|| format!("failed to parse {}", config_path.display()))?;
+
+    if links_file.links.is_empty() {
+        return Err(anyhow!("no links defined in {}", config_path.display()));
+    }
+
+    let client = build_client()?;
+    let mut failures = Vec::new();
+
+    for link in &links_file.links {
+        match check_link(&client, link) {
+            Ok(status) => print_success(link, status),
+            Err(err) => {
+                failures.push(link.name.clone());
+                eprintln!("[FAIL] {} ({}) — {}", link.name, link.url, err);
+            }
+        }
+    }
+
+    if failures.is_empty() {
+        println!(
+            "All {} OS download links are reachable.",
+            links_file.links.len()
+        );
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "{} download links failed ({}).",
+            failures.len(),
+            failures.join(", ")
+        ))
+    }
+}
+
+fn config_path_env() -> Result<PathBuf> {
+    let mut args = env::args().skip(1);
+    while let Some(arg) = args.next() {
+        if arg == "--config" {
+            if let Some(value) = args.next() {
+                return Ok(PathBuf::from(value));
+            }
+            break;
+        }
+    }
+    Ok(PathBuf::from("docs/os-download-links.toml"))
+}
+
+fn build_client() -> Result<Client> {
+    Client::builder()
+        .user_agent("mash-os-link-checker/1.0")
+        .timeout(Duration::from_secs(20))
+        .redirect(Policy::limited(10))
+        .build()
+        .context("failed to build HTTP client")
+}
+
+fn check_link(client: &Client, link: &OsLink) -> Result<StatusCode> {
+    let mut response = client
+        .head(&link.url)
+        .send()
+        .with_context(|| format!("failed to reach {}", link.url))?;
+
+    if response.status() == StatusCode::METHOD_NOT_ALLOWED {
+        response = client
+            .get(&link.url)
+            .send()
+            .with_context(|| format!("failed to reach {} via GET", link.url))?;
+    }
+
+    if response.status().is_success() {
+        Ok(response.status())
+    } else {
+        Err(anyhow!("HTTP {}", response.status()))
+    }
+}
+
+fn print_success(link: &OsLink, status: StatusCode) {
+    if let Some(desc) = &link.description {
+        println!("[OK] {} — {} ({})", link.name, desc, status);
+    } else {
+        println!("[OK] {} — {}", link.name, status);
+    }
+}


### PR DESCRIPTION
Closes #45.\n\n- add `tools/os-link-checker` as a tiny Rust binary that reads `docs/os-download-links.toml` and asserts that Fedora, Ubuntu, Manjaro, and Raspberry Pi OS download endpoints return success via HEAD requests\n- create a scheduled GitHub Actions workflow (`.github/workflows/os-download-links.yml`) that runs the new checker daily and exposes a badge in the README\n- include the canonical list of URLs under `docs/os-download-links.toml` so maintainers can update them as releases rotate\n\nTests:\n- cargo fmt -- --check\n- cargo clippy --all-targets --all-features -- -D warnings\n- cargo test --all-targets