### PR TITLE
docs: document optional OS download links (issue #39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The binary is output to `mash-installer/target/release/mash`.
 - [Deployment](docs/DEPLOYMENT.md) — Packaging and distribution
 - [Releasing](docs/RELEASING.md) — Release workflow and tooling
 - [Development Principles](docs/DOJO.md) — Code philosophy and rules
+- [Optional OS image links](docs/OS_IMAGE_LINKS.md) — Verified Ubuntu, Manjaro, and Raspberry Pi OS downloads
 
 ---
 

--- a/docs/OS_IMAGE_LINKS.md
+++ b/docs/OS_IMAGE_LINKS.md
@@ -1,0 +1,15 @@
+# OS image download guidance for optional platforms
+
+MASH willingly centers Fedora as the recommended OS for Raspberry Pi 4 installations. Still, advanced users can pursue alternative images if they need a different baseline. The following links point to the official download pages for the optional systems we currently support in documentation.
+
+| OS | Official link | Notes |
+| --- | --- | --- |
+| **Ubuntu Desktop** | https://ubuntu.com/download/desktop | Current LTS (24.04) and interim releases are served from this page. |
+| **Manjaro (XFCE / KDE / GNOME)** | https://manjaro.org/download/ | Downloads page that lists multiple editions plus their checksums. |
+| **Raspberry Pi OS (64-bit)** | https://www.raspberrypi.com/software/ | Canonical Raspberry Pi imagery (Lite, Desktop, and Raspberry Pi OS with desktop). |
+
+## Automation & verification
+To keep these links accurate, a GitHub Actions workflow (`.github/workflows/os-download-links.yml`) runs daily and hits the URLs listed in `docs/os-download-links.toml`. If a link returns a non-success HTTP status, the workflow fails and surfaces the broken URL. Update `docs/os-download-links.toml` in lockstep whenever official download pages change.
+
+## Fedora first
+We still recommend the Fedora KDE image because it is the native platform MASH has been optimized for. Follow the steps in `docs/QUICKSTART.md` or the README for downloading and flashing Fedora. Use these optional links only when you consciously opt out of the Fedora experience.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -39,6 +39,10 @@ sudo pacman -S parted rsync xz dosfstools e2fsprogs btrfs-progs
 
 ---
 
+## 🧭 Optional OS downloads
+
+Fedora remains the default and most thoroughly tested image for MASH, but curious users can explore other supported OSs. See [docs/OS_IMAGE_LINKS.md](./OS_IMAGE_LINKS.md) for the verified Ubuntu, Manjaro, and Raspberry Pi OS download pages, plus a note about the GitHub Actions link health job that watches those URLs.
+
 ## 🎯 Step 1: Identify Your Target Disk
 
 Connect your SD card or USB drive and identify it:


### PR DESCRIPTION
Closes #39.\n\n- added `docs/OS_IMAGE_LINKS.md` with the canonical Ubuntu, Manjaro, and Raspberry Pi OS download pages and a note about the automated link-check workflow\n- referenced the new optional-OS doc from the Quick Start guide and root README so Fedora remains the default while optional platforms are clearly linked\n- documented that the GitHub Actions job (`.github/workflows/os-download-links.yml`) keeps those URLs validated\n\nTests:\n- cargo fmt -- --check\n- cargo clippy --all-targets --all-features -- -D warnings\n- cargo test --all-targets