### PR TITLE
docs: audit Ferrari refactor plan (issue #37)

### DIFF
--- a/docs/v1.3.1-ferrari-audit.md
+++ b/docs/v1.3.1-ferrari-audit.md
@@ -1,0 +1,29 @@
+# v1.3.1 "Ferrari" Refactor Audit
+
+## Executive summary
+- The current Rust experience is spread across `mash-installer`, `tools/*`, and the emerging `mash-core` pieces. For v1.3.1 we should preserve the CLI surface but tighten layering, observability, and automation so MASH feels like a polished, "Ferrari"-level product.
+- The following sections highlight the highest-risk areas (stage runner, system/config helpers, docs/CI, testing) along with concrete follow-up work we have already started or should prioritize next.
+
+## Findings & proposed tasks
+1. **Stage runner and pipeline visibility** — The stage runner hides metadata behind string maps, making testing and reporting hard. Proposed work: improve the runner id/status, capture state in structured JSON, and expose it to the TUI/testing layers (issue #47 once `mash-core` lands).
+2. **Disk/system concerns** — `disk_ops`, `system_config::packages`, and `boot_config` are scattered. Introduce cohesive traits/callbacks, add tests, and ensure dry-run/cancellation invariants hold (we are already wiring disk ops tests in #46 and future work like #33 preflight). Keep CLI wrappers minimal.
+3. **Observability and resume instrumentation** — Structured logging (e.g., `tracing`) and progress reporting would help Dojo remediate failures. The planned CLI/resume coverage (#48) and the new coverage audit (issue #43) clarify these paths.
+4. **TUI state machine** — `tui::new_app` mixes input, state, and rendering. Introduce snapshot-based view models, stage summaries, and consistent emoji/UX cues while keeping the state machine explicit (#52–#54 highlight this work).
+5. **CI + release hygiene** — Optimized `Cargo` profiles (#38), automated OS link verification (#39 + #45), and the general coverage audit (#43) show we are in the middle of shoring up build/test docs. Keep the badge and automation so external contributors see the expectations.
+6. **Documentation & onboarding** — README, QUICKSTART, and new docs (Dojo catalogue, GitHub rename process, OS image links) now tell a consistent story. Add release notes for v1.3.1 once the next set of changes land.
+
+## Dead code / obsolete artifacts
+- `legacy/` and `legacy_scripts/` drift from the Rust story; consider archiving or removing them once the Rust replacement is stable.
+- The shell-based Dojo template and helper scripts should be reviewed: some have been replaced by Rust modules, so we can drop the copies once the new pipelines proved reliable.
+
+## Best-in-class patterns & alternatives
+- Prefer `reqwest` with `rustls` over `native-tls` to avoid platform-specific link issues (already done in the new `os-link-checker`).
+- Use `tracing`/`tracing-subscriber` to capture structured progress for both CLI and TUI, so the audit logs are useful when the Dojo TUI reports errors.
+- Keep stage runner state as a typed structure (not `Vec<(String, bool)>`) so both tests and the TUI can reason about the current stage ID.
+- Where we once shell-ed out there should be Rust implementations (disk/mount/format) to make dry-run testing deterministic.
+
+## Next steps
+- Finish issue #47 (stage runner coverage) when `mash-core` lands.
+- Continue #48 for CLI/resume once the state manager and CLI modules exist.
+- Close out the Dojo catalogue work (#49–#54) to keep the UX story polished.
+- Follow up with #33 (preflight invariants) and #45 (link automation) to lock in the safety/performance pieces.


### PR DESCRIPTION
Closes #37.\n\n- added `docs/v1.3.1-ferrari-audit.md` to summarize the audit findings, identify dead code, document best-in-class patterns, and list the next refactor/test/documentation tasks (including #38-#45 and #46-#48).\n- the audit captures the move toward safer stage-runner coverage, improved CI, Dojo theming, and documentation hygiene that define the Ferrari-level polish goal.\n\nTests:\n- cargo fmt -- --check\n- cargo clippy --all-targets --all-features -- -D warnings\n- cargo test --all-targets