### PR TITLE
docs: refresh docs for v1.3.1 (issue #42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The binary is output to `mash-installer/target/release/mash`.
 - [Deployment](docs/DEPLOYMENT.md) — Packaging and distribution
 - [Releasing](docs/RELEASING.md) — Release workflow and tooling
 - [Development Principles](docs/DOJO.md) — Code philosophy and rules
+- [v1.3.1 Release Notes](docs/v1.3.1-release-notes.md) — Ferrari polish summary
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -59,6 +59,10 @@ The built binary requires these tools at runtime:
 - `mkfs.btrfs` (btrfs-progs)
 - `losetup` (util-linux)
 
+## 🔗 OS image verification
+
+Fedora Workstation remains the primary image for MASH; grab it from https://getfedora.org/en/workstation/download/. Optional OS downloads are documented in `docs/OS_IMAGE_LINKS.md`, and `.github/workflows/os-download-links.yml` pings those URLs daily via HTTP HEAD to keep them accurate. Update the `docs/os-download-links.toml` list and rerun the workflow if any link changes.
+
 ---
 
 ## 🏗️ Building

--- a/docs/DOJO.md
+++ b/docs/DOJO.md
@@ -192,6 +192,10 @@ When in doubt, ask: "Would I trust this tool with my data?"
 
 ---
 
+## Dojo Program Catalogue
+
+The Training Ground entry point now surfaces the curated catalogue described in `docs/dojo/catalogue_content_proposal.md`. Each category highlights a trusted default and a set of alternatives so users can choose intent-driven software without guessing trade-offs. The `v1.3.1` release notes (`docs/v1.3.1-release-notes.md`) capture how this catalogue fits into the larger Dojo narrative.
+
 ## See Also
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) — Technical design

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -39,6 +39,14 @@ sudo pacman -S parted rsync xz dosfstools e2fsprogs btrfs-progs
 
 ---
 
+## 🧭 Optional OS downloads
+
+Fedora remains the default and most thoroughly tested image for MASH, but curious users can explore other supported OSs. See [docs/OS_IMAGE_LINKS.md](./OS_IMAGE_LINKS.md) for the verified Ubuntu, Manjaro, and Raspberry Pi OS download pages, plus a note about the GitHub Actions link health job that watches those URLs.
+
+## 🔮 Dojo Program Catalogue
+
+The Training Ground flow surfaces a curated catalogue (`docs/dojo/catalogue_content_proposal.md`) that groups software by intent and protects defaults with gated alternatives. More context is available in the [v1.3.1 release notes](./v1.3.1-release-notes.md) describing the Ferrari polish.
+
 ## 🎯 Step 1: Identify Your Target Disk
 
 Connect your SD card or USB drive and identify it:

--- a/docs/v1.3.1-release-notes.md
+++ b/docs/v1.3.1-release-notes.md
@@ -1,0 +1,21 @@
+# v1.3.1 "Ferrari" Release Notes
+
+This release sharpens the documentation, UX muscle, and release hygiene so that MASH feels like a premium experience on Raspberry Pi 4.
+
+## Highlights
+- **Dojo Program Catalogue**: curated categories with a default+alternatives model now appear in the Training Ground experience; see `docs/dojo/catalogue_content_proposal.md` for the entire schema and offerings.
+- **OS image hygiene**: Fedora remains the recommended image while Ubuntu Desktop, Manjaro, and Raspberry Pi OS download pages are verified daily via `.github/workflows/os-download-links.yml` and documented in `docs/OS_IMAGE_LINKS.md`.
+- **Test coverage audit**: we documented the coverage gaps in `docs/coverage/test_coverage_audit.md`, spun up download helpers (#46), and outlined the remaining coverage roadmap (#47/#48) so regressions are easier to catch.
+- **Repository hygiene & policy**: ABB branch discipline, `.gitignore` cleanup, and the branch-management guide in `docs/RELEASING.md` (plus the cargo profile tweaks in #38) keep local iterations fast and safe.
+
+## Details
+- **Training Ground narrative**: `docs/DOJO.md` now links to the catalog, and `docs/QUICKSTART.md` references the curated Dojo/TG experience alongside the optional OS download guidance.
+- **Documentation refresh**: README, Quick Start, Deployment, Release, and Roadmap all point to the new docs and badges so contributors understand the latest workflow and UI naming.
+- **Automation & tooling**: `tools/os-link-checker` plus CI coverage automation (#45/#43) and the `issue/38` profile optimizations reduce rebuild time and keep OS links accurate.
+
+## Testing & validation
+Run the standard commands to verify the release:
+
+- `cargo fmt -- --check`
+- `cargo clippy --all-targets --all-features -- -D warnings`
+- `cargo test --all-targets`


### PR DESCRIPTION
Closes #42.\n\n- added `docs/v1.3.1-release-notes.md` documenting the Ferrari-level polish and referencing the Training Ground/Dojo catalogue, release policy, and verification automation\n- updated README, QUCI KSTART, DEPLOYMENT, and DOJO docs so the optional OS downloads, Dojo Training Ground catalog, and release notes are prominently linked\n- noted the new OS image verifier workflow in Deployment so package builders understand where to find the verified Ubuntu/Manjaro/Raspberry Pi OS pages\n\nTests:\n- cargo fmt -- --check\n- cargo clippy --all-targets --all-features -- -D warnings\n- cargo test --all-targets